### PR TITLE
added error message to tooltip on jobs home page

### DIFF
--- a/js/job_metrics.js
+++ b/js/job_metrics.js
@@ -61,9 +61,11 @@ function serverJobs(){
         if(jobsDesc[i].status == 'ok'){cardColor = 'text-light bg-success'}
         else if(jobsDesc[i].status == 'error'){cardColor = 'text-light bg-danger'}
         else{cardColor = 'text-light bg-secondary'};
+        if(jobsDesc[i].message == null){var eMessage = ''}
+        else{var eMessage = jobsDesc[i].message};
         jobsGrid.push(`
             <div class="card ${cardColor} mb-3" style="display:inline-block">
-                <div class="card-body"  data-toggle="tooltip" data-html="true" title="${jobsDesc[i].description}">
+                <div class="card-body"  data-toggle="tooltip" data-html="true" title="${eMessage}">
                     ${jobsDesc[i].name}
                 </div>
             </div>


### PR DESCRIPTION
This now shows the error message in the tooltip (Jobs Home Page) as opposed to the jobs description.  If there were no errors the tooltip will be empty.